### PR TITLE
Fix undefined indexes

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ class IndexArray extends Array {
             let index = {}
             for (let i = this.length-1; i >= 0; i--) {
                 let value = this[i][key]
-                index[value] = i
+                if (value !== undefined) index[value] = i
             }
             this.indexes[key] = index
         }
@@ -93,7 +93,7 @@ class IndexArray extends Array {
         let i = this.length - 1
         for (let key in this.indexes) {
             let value = item[key]
-            this.indexes[key][value] = i
+            if (value !== undefined) this.indexes[key][value] = i
         }
         return result
     }
@@ -143,8 +143,13 @@ function setHandler(obj, prop, value) {
     let oldValue = obj[prop]
     if (this.indexes[prop]) {
         let i = this.indexes[prop][oldValue]
-        delete this.indexes[prop][oldValue]
-        this.indexes[prop][value] = i
+        if (i !== undefined) {
+            delete this.indexes[prop][oldValue]
+            this.indexes[prop][value] = i
+        } else {
+            // We can't find the index of the original object. For now, we just remove the index.
+            delete this.indexes[prop]
+        }
     }
 
     return Reflect.set(obj, prop, value)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "index-array",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "An array of objects that is automatically indexed when you search it.",
   "main": "index.js",
   "scripts": {

--- a/tests/index-array.test.js
+++ b/tests/index-array.test.js
@@ -63,6 +63,16 @@ describe('fetch', () => {
     expect(Object.keys(array.indexes).sort()).toEqual(['id', 'name'])
     expect(array.indexes).toEqual({id: {1: 0, 3: 1}, name: {one: 0, three: 1}})
   })
+
+  test('it does not add undefined to index when an object is missing a key', () => {
+    firstObject = {id: 1, name: 'one'}
+    secondObject = {name: 'three'}
+    array = new IndexArray(firstObject, secondObject)
+    array.fetch({id: 1})
+    array.fetch({name: 'one'})
+
+    expect(array.indexes).toEqual({id: {1: 0}, name: {one: 0, three: 1}})
+  })
 })
 
 
@@ -146,6 +156,15 @@ describe('push', () => {
     expect(array.length).toEqual(3)
     expect(array[2]).toEqual(newObject)
     expect(array.indexes).toEqual({id: {1: 0, 3: 1, 5: 2}})
+  })
+
+  test('does not add undefined to index', () => {
+    let array = new IndexArray({id: 1, name: 'one'})
+    array.fetch({id: 1})
+    let newObject = {name: 'two'}
+    array.push(newObject)
+
+    expect(array.indexes).toEqual({id: {1: 0}})
   })
 })
 
@@ -273,6 +292,21 @@ describe('proxy wrapper', () => {
     array[1].id = 4
     expect(array.indexes).toEqual({id: {1: 0, 4: 1}})
     expect(array.fetch({id: 4})).toEqual({id: 4, name: 'two'})
+  })
+
+  test('returns the correct object after pushing objects with missing keys', () => {
+    let firstObject = {id: 1, name: 'one'}
+    let secondObject = {name: 'three'}
+    let thirdObject = {name: 'five'}
+    let array = new IndexArray(firstObject)
+    array.fetch({id: 1})
+    array.push(secondObject)
+    array.push(thirdObject)
+
+    array[1].id = 3
+    expect(array.fetch({id: 3})).toEqual(secondObject)
+    array[2].id = 5
+    expect(array.fetch({id: 5})).toEqual(thirdObject)
   })
 })
 


### PR DESCRIPTION
Previously, undefined was added to the index as such:
```js
let array = new IndexArray({id: 1})
array.fetch({id: 1})
array.push({}) // array.indexes.id == {1: 0, undefined: 1}
array.push({}) // array.indexes.id == {1: 0, undefined: 2}
array[1].id = 2 // array.indexes.id == {1: 0, 2: 2} // This is wrong
```
Now, undefined values are no longer added to the index.